### PR TITLE
Groups - h changes used by client's new configuration option: 'pageGroups'

### DIFF
--- a/h/routes.py
+++ b/h/routes.py
@@ -104,6 +104,14 @@ def includeme(config):
                      traverse='/{id}')
     config.add_route('api.profile', '/api/profile')
     config.add_route('api.debug_token', '/api/debug-token')
+    config.add_route('api.group_read',
+                     '/api/groups/{pubid}/{slug:[^/]*}',
+                     factory='h.models.group:GroupFactory',
+                     traverse='/{pubid}')
+    config.add_route('api.group_read_noslug',
+                     '/api/groups/{pubid}',
+                     factory='h.models.group:GroupFactory',
+                     traverse='/{pubid}')
     config.add_route('api.group_member',
                      '/api/groups/{pubid}/members/{user}',
                      factory='h.models.group:GroupFactory',

--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -8,7 +8,8 @@
   <script type="application/json" class="js-hypothesis-config">
     {
       "openSidebar": true,
-      "openLoginForm": true
+      "openLoginForm": true,
+      "pageGroups": ["http://h.hypothesis:5000/groups/MGkYz9j2/http-test-localhost"]
     }
   </script>
   {% if not is_onboarding %}

--- a/h/templates/help.html.jinja2
+++ b/h/templates/help.html.jinja2
@@ -8,8 +8,7 @@
   <script type="application/json" class="js-hypothesis-config">
     {
       "openSidebar": true,
-      "openLoginForm": true,
-      "pageGroups": ["http://h.hypothesis:5000/groups/MGkYz9j2/http-test-localhost"]
+      "openLoginForm": true
     }
   </script>
   {% if not is_onboarding %}

--- a/h/views/admin_groups.py
+++ b/h/views/admin_groups.py
@@ -109,7 +109,7 @@ class AdminGroupCreateController(object):
             groups_service = self.request.find_service(name='group')
             group = groups_service.create(
                 name=form_data['name'],
-                authority=self.request.authority,
+                authority=form_data['authority'],
                 description=form_data.get('description'),
                 userid=self.request.authenticated_userid,
                 type_=form_data['group_type'])

--- a/h/views/api.py
+++ b/h/views/api.py
@@ -46,7 +46,7 @@ def index(context, request):
     # parameter names are added, we'll need to add them here, or this view will
     # break (and get caught by the `test_api_index` functional test).
     templater = AngularRouteTemplater(request.route_url,
-                                      params=['id', 'pubid', 'user'])
+                                      params=['id', 'pubid', 'user', 'slug'])
 
     links = {}
     for link in api_links:

--- a/h/views/api_groups.py
+++ b/h/views/api_groups.py
@@ -34,8 +34,7 @@ def remove_member(group, request):
             description='Read a Group',
             renderer='json')
 def get_group(group, request):
-    return dict((f, getattr(group, f, None)) for f in ('pubid', 'description', 'name'))
-
+    return dict([(f, getattr(group, f, None)) for f in ('description', 'name')], id=group.pubid)
 
 @api_config(route_name='api.group_read_noslug',
             link_name='group.read',

--- a/h/views/groups.py
+++ b/h/views/groups.py
@@ -4,6 +4,7 @@ import deform
 from pyramid import httpexceptions
 from pyramid import security
 from pyramid.config import not_
+from pyramid.exceptions import HTTPNotFound
 from pyramid.view import view_config, view_defaults
 
 from h import form
@@ -130,6 +131,8 @@ def read_unauthenticated(group, request):
              decorator=cors_policy)
 def read_unauthenticated_json(group, request):
     """If the end-user wants json, redirect to the API"""
+    if not group:
+        raise HTTPNotFound()
     url = request.route_path('api.group_read',
                              pubid=group.pubid,
                              slug=group.slug)
@@ -155,4 +158,4 @@ def check_slug(group, request):
     if slug is None or slug != group.slug:
         path = request.route_path(
             'group_read', pubid=group.pubid, slug=group.slug)
-        return httpexceptions.HTTPMovedPermanently(path)
+        raise httpexceptions.HTTPMovedPermanently(path)


### PR DESCRIPTION
We're adding the ability for publishers to configure hypothesis/clients to feature one or more groups. So the client will show groups you're a member of, but now also groups the publisher want to promote.

Publishers can configure one or more `pageGroups` (happy to change that to whatever) like:
```
window.hypothesisConfig = function () {
    return {
        pageGroups: [
            "http://h.hypothesis:5000/groups/2JKqAjYE/scipub-com-open-group",
            "http://h.hypothesis:5000/groups/wg54vyqQ/h-hypothesis-open",
        ]
    };
};
```

The idea is here is it's "Just the group URL" that you'd get by using a web browser to find the group.

The client can benefit from being able to dereference these group URLs to a JSON representation. This Pull Request does a couple things
* h.views.api_groups
  * Add get_group handler for API to get the id, description, name of a group
* h.views.groups
  * read_unauthenticated_json new func that responds to JSON requests to route_name='group_read'. It redirects to the api.group_read route.
    * This way the urls that users enter, which resolve to HTML in a web browser, can point over to the API and say 'look over there for the group'. I assumed it might be preferred to centralized JSON-responses in the API, but we could also have h.views.groups respond with JSON here directly.
  * route group_read now respond to OPTIONS requests for CORS supprot
* tests.h.views.groups_test - tests that these group URLs eventually redirect to a JSON object #